### PR TITLE
Fixed typo in config

### DIFF
--- a/conf/config_sample.py
+++ b/conf/config_sample.py
@@ -25,7 +25,7 @@ COINDAEMON_TRUSTED_PASSWORD = 'somepassword'
 # For Reward type there is POW and POS. please ensure you choose the currect type.
 # For Coins which support TX Messages please enter yes in the TX selection
 COINDAEMON_ALGO = 'scrypt'
-COINDAEMON_Reard = 'POW'
+COINDAEMON_Reward = 'POW'
 COINDAEMON_TX_MSG = 'no'
 
 # If you want a TX message in the block if the coin supports it, enter it below


### PR DESCRIPTION
`COINDAEMON_Reard` should be `COINDAEMON_Reward`.
As it is, the config line will be ignored and won't work.
Plays along with #58
