### PR TITLE
Add the option to pass scrypt hash to the submit block test

### DIFF
--- a/conf/config_sample.py
+++ b/conf/config_sample.py
@@ -186,3 +186,7 @@ NOTIFY_EMAIL_SERVER = 'localhost'  # E-Mail Sender
 NOTIFY_EMAIL_USERNAME = ''    # E-Mail server SMTP Logon
 NOTIFY_EMAIL_PASSWORD = ''
 NOTIFY_EMAIL_USETLS = True
+
+#Pass scrypt hash to submit block check.
+#Use if submit block is returning errors and marking submitted blocks invaild upstream, but the submitted blocks are being a accepted by the coin daemon into the block chain.
+BLOCK_CHECK_SCRYPT_HASH = False

--- a/lib/bitcoin_rpc.py
+++ b/lib/bitcoin_rpc.py
@@ -40,7 +40,7 @@ class BitcoinRPC(object):
             }))
 
     @defer.inlineCallbacks
-    def submitblock(self, block_hex, block_hash_hex):
+    def submitblock(self, block_hex, hash_hex):
         # Try submitblock if that fails, go to getblocktemplate
         try:
 	    log.info("Submitting Block with Submit Block ")
@@ -57,7 +57,7 @@ class BitcoinRPC(object):
  
         if json.loads(resp)['result'] == None:
             # make sure the block was created. 
-            defer.returnValue((yield self.blockexists(block_hash_hex)))
+            defer.returnValue((yield self.blockexists(hash_hex)))
         else:
             defer.returnValue(False)
 
@@ -91,12 +91,12 @@ class BitcoinRPC(object):
         defer.returnValue(json.loads(resp)['result'])
 
     @defer.inlineCallbacks
-    def blockexists(self, block_hash_hex):
-        resp = (yield self._call('getblock', [block_hash_hex,]))
-        if "hash" in json.loads(resp)['result'] and json.loads(resp)['result']['hash'] == block_hash_hex:
-            log.debug("Block Confirmed: %s" % block_hash_hex)
+    def blockexists(self, hash_hex):
+        resp = (yield self._call('getblock', [hash_hex,]))
+        if "hash" in json.loads(resp)['result'] and json.loads(resp)['result']['hash'] == hash_hex:
+            log.debug("Block Confirmed: %s" % hash_hex)
             defer.returnValue(True)
         else:
-            log.info("Cannot find block for %s" % block_hash_hex)
+            log.info("Cannot find block for %s" % hash_hex)
             defer.returnValue(False)
             

--- a/lib/bitcoin_rpc_manager.py
+++ b/lib/bitcoin_rpc_manager.py
@@ -88,10 +88,10 @@ class BitcoinRPCManager(object):
 	    except:
 		self.next_connection()
 
-    def submitblock(self, block_hex, block_hash_hex):
+    def submitblock(self, block_hex, hash_hex):
 	while True:
 	    try:
-		return self.conns[self.curr_conn].submitblock(block_hex, block_hash_hex)
+		return self.conns[self.curr_conn].submitblock(block_hex, hash_hex)
 	    except:
 		self.next_connection()
 

--- a/lib/template_registry.py
+++ b/lib/template_registry.py
@@ -279,7 +279,11 @@ class TemplateRegistry(object):
                             
             # 7. Submit block to the network
             serialized = binascii.hexlify(job.serialize())
-            on_submit = self.bitcoin_rpc.submitblock(serialized, block_hash_hex)
+            if settings.BLOCK_CHECK_SCRYPT_HASH:
+                on_submit = self.bitcoin_rpc.submitblock(serialized, scrypt_hash_hex)
+            else:
+                on_submit = self.bitcoin_rpc.submitblock(serialized, block_hash_hex)
+                
             if on_submit:
                 self.update_block()
 


### PR DESCRIPTION
Added condition to templateregistry.py allowing the choice between sending the scrypt hash or plain hash to the submit block function.

Changed the name of the variable passed between the modules to hash_hex for clarity, as it could be either type of block hash.

Added the option in the configuration file example.
