### PR TITLE
Added new configuration option STRATUM_MINING_PROCESS_NAME.

### DIFF
--- a/conf/config_sample.py
+++ b/conf/config_sample.py
@@ -46,6 +46,9 @@ Tx_Message = 'http://github.com/ahmedbodi/stratum-mining'
 
 # ******************** GENERAL SETTINGS ***************
 
+# Set process name of twistd, much more comfortable if you run multiple processes on one machine
+STRATUM_MINING_PROCESS_NAME= 'twistd-stratum-mining'
+
 # Enable some verbose debug (logging requests and responses).
 DEBUG = False
 

--- a/launcher.tac
+++ b/launcher.tac
@@ -6,6 +6,7 @@ import os, sys
 sys.path = [os.path.join(os.getcwd(), 'conf'),os.path.join(os.getcwd(), 'externals', 'stratum-mining-proxy'),] + sys.path
 
 from twisted.internet import defer
+from twisted.application.service import Application, IProcess
 
 # Run listening when mining service is ready
 on_startup = defer.Deferred()
@@ -14,6 +15,7 @@ import stratum
 import lib.settings as settings
 # Bootstrap Stratum framework
 application = stratum.setup(on_startup)
+IProcess(application).processName = settings.STRATUM_MINING_PROCESS_NAME
 
 # Load mining service into stratum framework
 import mining


### PR DESCRIPTION
If you run multiple instances of stratum mining it's nice to set a process identifier / name. 

With this small change you can easily find the right process via ps on console.

``` shell
stratum     11306  0.2  1.1 387428 23848 ?        Sl   10:17   0:03 twistd-stratum-mining /usr/local/bin/twistd --originalname -y launcher.tac
```
