### PR TITLE
[FIX] Coind error: Invalid mode for ppcoin, possibly others

### DIFF
--- a/lib/bitcoin_rpc.py
+++ b/lib/bitcoin_rpc.py
@@ -78,6 +78,8 @@ class BitcoinRPC(object):
             if (str(e) == "500 Internal Server Error"):
                 resp = (yield self._call('getblocktemplate', []))
                 defer.returnValue(json.loads(resp)['result'])
+            else:
+                raise
                                                   
     @defer.inlineCallbacks
     def prevhash(self):


### PR DESCRIPTION
If getblocktemplate {} fails, try getblocktemplate with no arguments.
