### PR TITLE
Fix user_exists to deal with cache expiration

### DIFF
--- a/mining/DBInterface.py
+++ b/mining/DBInterface.py
@@ -202,7 +202,7 @@ class DBInterface():
     def user_exists(self, username):
         if self.cache.get(username) is not None:
             return True
-        user = self.dbi.get_user(username)
+        user = self.get_user(username)
         return user is not None 
 
     def insert_user(self, username, password):        


### PR DESCRIPTION
If user expired or deleted from cache, call dbinterface.get_user instead of actual db get_user. This makes sure it's put back into the cache.
