### PR TITLE
Fix bug with always new block

### DIFF
--- a/lib/block_updater.py
+++ b/lib/block_updater.py
@@ -46,7 +46,7 @@ class BlockUpdater(object):
                 current_prevhash = None
                 
             log.info("Checking for new block.")
-            prevhash = util.reverse_hash((yield self.bitcoin_rpc.prevhash()))
+            prevhash = (yield self.bitcoin_rpc.prevhash())
             if prevhash and prevhash != current_prevhash:
                 log.info("New block! Prevhash: %s" % prevhash)
                 update = True


### PR DESCRIPTION
So, I didn't know new standard for bitcoind to return alreaday reversed hash, so there's bugfix for that.
I did not found any other real usage of prevhash function in code. Only in
```
lib/block_template.py:88:        self.prevhash_bin = binascii.unhexlify(util.reverse_hash(data['previousblockhash']))
```
But this function issn't used anywhere.