### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Description
+# Description
 Stratum-mining is a pooled mining protocol. It is a replacement for *getwork* based pooling servers by allowing clients to generate work. The stratum protocol is described [here](http://mining.bitcoin.cz/stratum-mining) in full detail.
 
 This is a implementation of stratum-mining for most coins. It is compatible with *MPOS* as it complies with the standards of *pushpool*. The end goal is to build on these standards to come up with a more stable solution.
@@ -7,7 +7,7 @@ The goal is to make a reliable stratum mining server for a wide range of coins u
 
 **NOTE:** This fork is still in development. Many features may be broken. Please report any broken features or issues.
 
-#Features
+# Features
 
 * Stratum Mining Pool 
 * Solved Block Confirmation
@@ -23,11 +23,11 @@ The goal is to make a reliable stratum mining server for a wide range of coins u
 * Proof Of Work and Proof of Stake Coin Support
 * Transaction Messaging Support
 
-#Donations 
+# Donations 
 * BTC:  1D9sGeqx5TVzcCSdmiUqxtdqbc8puyVM9N
 
 
-#Requirements
+# Requirements
 *stratum-mining* is built in python. I have been testing it with 2.7.3, but it should work with other versions. The requirements for running the software are below.
 * Python 2.7+
 * python-twisted
@@ -53,23 +53,23 @@ Other coins have been known to work with this implementation. I have tested with
 * Quark
 * Securecoin
 
-#Installation
+# Installation
 
 The installation of this *stratum-mining* can be found in the Repo Wiki. 
 
-#Contact
+# Contact
 I am available in the #MPOS, #crypto-expert, #digitalcoin, and #worldcoin channels on freenode. 
 Although i am willing to provide support through IRC please file issues on the repo.
 Issues as a direct result of stratum will be helped with as much as possible
 However issues related to a coin daemon's setup and other non stratum issues, 
 Please research and attempt to debug first.
 
-#Credits
+# Credits
 
 * Original version by Slush0 and ArtForz (original stratum code)
 * More Features added by GeneralFault, Wadee Womersley, Viperaus, TheSeven and Moopless
 * Multi Algo, Vardiff, DB and MPOS support done by Ahmed_Bodi, penner42 and Obigal
 
-#License
+# License
 This software is provides AS-IS without any warranties of any kind. Please use at your own risk. 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
